### PR TITLE
adapt to mirah 0.1.3 changes using Mirac.compile. Fix test mojo phase an...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.mirah.maven</groupId>
   <artifactId>maven-mirah-plugin</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-mirah-plugin</name>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.mirah</groupId>
       <artifactId>mirah-complete</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.mirah</groupId>
       <artifactId>mirah-complete</artifactId>
-      <version>0.1.3</version>
+      <version>0.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/mirah/maven/AbstractMirahMojo.java
+++ b/src/main/java/org/mirah/maven/AbstractMirahMojo.java
@@ -5,15 +5,13 @@ import org.apache.maven.plugin.CompilationFailureException;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 
 import java.util.List;
 import java.util.ArrayList;
 
 import org.codehaus.plexus.util.StringUtils;
 
-import org.mirah.MirahCommand;
+import org.mirah.tool.Mirahc;
 
 public abstract class AbstractMirahMojo extends CompilerMojo {
     /**
@@ -39,7 +37,7 @@ public abstract class AbstractMirahMojo extends CompilerMojo {
     protected String outputDirectory;
     /**
      * Classes source directory
-     * @parameter expression="src/main/mirah"
+     * @parameter expression="${basedir}/src/main/mirah"
      */
     protected String sourceDirectory;
     /**
@@ -48,7 +46,10 @@ public abstract class AbstractMirahMojo extends CompilerMojo {
      */
     protected boolean verbose;
 
-    protected void executeMirahCompiler(String output, boolean bytecode) throws MojoExecutionException {
+	protected List<String> getClassPathElements(){
+		return classpathElements;
+	}
+    protected void executeMirahCompiler(String output, String sourceDirectory, boolean verbose, boolean bytecode) throws MojoExecutionException {
         File d = new File(output);
         if (!d.exists()) {
             d.mkdirs();
@@ -60,21 +61,31 @@ public abstract class AbstractMirahMojo extends CompilerMojo {
         if (verbose)
             arguments.add("-V");
 
-        arguments.add("--cd");
-        arguments.add(sourceDirectory);
         arguments.add("-d");
         arguments.add(output);
 
         /* do I really need this? */
-        arguments.add("-c");
-        arguments.add(StringUtils.join(classpathElements.iterator(), File.pathSeparator));
+        arguments.add("-cp");
+        arguments.add(StringUtils.join(getClassPathElements().iterator(), File.pathSeparator));
 
-        arguments.add(".");
 
-        try {
-            MirahCommand.compile(arguments);
-        } catch (Exception e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        }
+	    File file = new File(sourceDirectory);
+	    if(!file.exists()){
+		    getLog().info("Source directory: " + file.getAbsolutePath() + " does not exists or not accessible. Skip mirahc.");
+	    } else {
+		    arguments.add(sourceDirectory);
+		    mojoCompile(arguments);
+	    }
+
     }
+
+	public static void mojoCompile(List<String> arguments) throws MojoExecutionException {
+		try {
+			Mirahc mirahc = new Mirahc();
+			int result = mirahc.compile(arguments.toArray(new String[arguments.size()]));
+			if(result != 0) throw new MojoExecutionException("Compilation failed with arguments: " + arguments);
+		} catch (Exception e) {
+			throw new MojoExecutionException(e.getMessage(), e);
+		}
+	}
 }

--- a/src/main/java/org/mirah/maven/AbstractMirahMojo.java
+++ b/src/main/java/org/mirah/maven/AbstractMirahMojo.java
@@ -46,10 +46,18 @@ public abstract class AbstractMirahMojo extends CompilerMojo {
      */
     protected boolean verbose;
 
-	protected List<String> getClassPathElements(){
-		return classpathElements;
-	}
-    protected void executeMirahCompiler(String output, String sourceDirectory, boolean verbose, boolean bytecode) throws MojoExecutionException {
+    /**
+     * Show log
+     *
+     * @parameter newClosures, default false
+     */
+    protected boolean newClosures;
+
+    protected List<String> getClassPathElements() {
+        return classpathElements;
+    }
+
+    protected void executeMirahCompiler(String output, String sourceDirectory, boolean verbose, boolean newClosures, boolean bytecode) throws MojoExecutionException {
         File d = new File(output);
         if (!d.exists()) {
             d.mkdirs();
@@ -68,24 +76,27 @@ public abstract class AbstractMirahMojo extends CompilerMojo {
         arguments.add("-cp");
         arguments.add(StringUtils.join(getClassPathElements().iterator(), File.pathSeparator));
 
+        if (newClosures) {
+            arguments.add("-new-closures");
+        }
 
-	    File file = new File(sourceDirectory);
-	    if(!file.exists()){
-		    getLog().info("Source directory: " + file.getAbsolutePath() + " does not exists or not accessible. Skip mirahc.");
-	    } else {
-		    arguments.add(sourceDirectory);
-		    mojoCompile(arguments);
-	    }
+        File file = new File(sourceDirectory);
+        if (!file.exists()) {
+            getLog().info("Source directory: " + file.getAbsolutePath() + " does not exists or not accessible. Skip mirahc.");
+        } else {
+            arguments.add(sourceDirectory);
+            mojoCompile(arguments);
+        }
 
     }
 
-	public static void mojoCompile(List<String> arguments) throws MojoExecutionException {
-		try {
-			Mirahc mirahc = new Mirahc();
-			int result = mirahc.compile(arguments.toArray(new String[arguments.size()]));
-			if(result != 0) throw new MojoExecutionException("Compilation failed with arguments: " + arguments);
-		} catch (Exception e) {
-			throw new MojoExecutionException(e.getMessage(), e);
-		}
-	}
+    public static void mojoCompile(List<String> arguments) throws MojoExecutionException {
+        try {
+            Mirahc mirahc = new Mirahc();
+            int result = mirahc.compile(arguments.toArray(new String[arguments.size()]));
+            if (result != 0) throw new MojoExecutionException("Compilation failed with arguments: " + arguments);
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/org/mirah/maven/MirahCompilerMojo.java
+++ b/src/main/java/org/mirah/maven/MirahCompilerMojo.java
@@ -13,6 +13,6 @@ import org.apache.maven.plugin.MojoExecutionException;
  */
 public class MirahCompilerMojo extends AbstractMirahMojo {
    public void execute() throws MojoExecutionException, CompilationFailureException {
-       executeMirahCompiler(outputDirectory, true);
+	   executeMirahCompiler(outputDirectory, sourceDirectory, verbose, true);
    }
 }

--- a/src/main/java/org/mirah/maven/MirahCompilerMojo.java
+++ b/src/main/java/org/mirah/maven/MirahCompilerMojo.java
@@ -12,7 +12,7 @@ import org.apache.maven.plugin.MojoExecutionException;
  * @requiresDependencyResolution compile
  */
 public class MirahCompilerMojo extends AbstractMirahMojo {
-   public void execute() throws MojoExecutionException, CompilationFailureException {
-	   executeMirahCompiler(outputDirectory, sourceDirectory, verbose, true);
-   }
+    public void execute() throws MojoExecutionException, CompilationFailureException {
+        executeMirahCompiler(outputDirectory, sourceDirectory, verbose, newClosures, true);
+    }
 }

--- a/src/main/java/org/mirah/maven/MirahSourcesMojo.java
+++ b/src/main/java/org/mirah/maven/MirahSourcesMojo.java
@@ -21,6 +21,6 @@ public class MirahSourcesMojo extends AbstractMirahMojo {
 
     public void execute() throws MojoExecutionException, CompilationFailureException {
         compileSourceRoots.add(generatedSrc);
-        executeMirahCompiler(generatedSrc, false);
+        executeMirahCompiler(generatedSrc, outputDirectory, verbose, false);
     }
 }

--- a/src/main/java/org/mirah/maven/MirahSourcesMojo.java
+++ b/src/main/java/org/mirah/maven/MirahSourcesMojo.java
@@ -21,6 +21,6 @@ public class MirahSourcesMojo extends AbstractMirahMojo {
 
     public void execute() throws MojoExecutionException, CompilationFailureException {
         compileSourceRoots.add(generatedSrc);
-        executeMirahCompiler(generatedSrc, outputDirectory, verbose, false);
+        executeMirahCompiler(generatedSrc, outputDirectory, verbose, false, false);
     }
 }

--- a/src/main/java/org/mirah/maven/MirahTestCompilerMojo.java
+++ b/src/main/java/org/mirah/maven/MirahTestCompilerMojo.java
@@ -23,13 +23,13 @@ import org.mirah.tool.Mirahc;
  */
 public class MirahTestCompilerMojo extends AbstractMirahMojo {
 
-	/**
-	 * Set this to 'true' to bypass unit tests entirely.
-	 * Its use is NOT RECOMMENDED, but quite convenient on occasion.
-	 *
-	 * @parameter expression="${maven.test.skip}"
-	 */
-	private boolean skip;
+    /**
+     * Set this to 'true' to bypass unit tests entirely.
+     * Its use is NOT RECOMMENDED, but quite convenient on occasion.
+     *
+     * @parameter expression="${maven.test.skip}"
+     */
+    private boolean skip;
 
     /**
      * Project classpath.
@@ -64,16 +64,23 @@ public class MirahTestCompilerMojo extends AbstractMirahMojo {
      */
     private boolean verbose;
 
-	protected List<String> getClassPathElements(){
-		return classpathElements;
-	}
+    /**
+     * Show log
+     *
+     * @parameter newClosures, default false
+     */
+    protected boolean newClosures;
+
+    protected List<String> getClassPathElements() {
+        return classpathElements;
+    }
 
     public void execute() throws MojoExecutionException, CompilationFailureException {
-	    if(skip){
-		    getLog().info("skiping mirah tests compilation");
-	    } else {
-		    executeMirahCompiler(outputDirectory, sourceDirectory, verbose, true);
-	    }
+        if (skip) {
+            getLog().info("skiping mirah tests compilation");
+        } else {
+            executeMirahCompiler(outputDirectory, sourceDirectory, verbose, newClosures, true);
+        }
     }
 
 }


### PR DESCRIPTION
Modified mirah maven plugin to:
- use latest 0.1.3 mirah
- use Mirah.new.compile instead of MirahCommand
- bumped version to 1.2
- source generation mojo is still present, but is not working as --java switch not supported
